### PR TITLE
👽 Add support for react-native-reanimated>=3

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ export default optimizeHeavyScreen(Screen, OptionalPlaceHolderScreen, {
 - `Placeholder` (optional) Non-heavy React component that renders in the meantime.
 - `options` (optional) Dictionary with the following options:
   - `disableHoistStatics`: (optional) If `true`, the `Screen`'s statics (like `navigationOptions`, etc.) will not be passed on. Default: `false`.
-  - `transition`: (optional) custom transition prop for Reanimated's `Transitioning.View` component. See `react-native-reanimated` [docs](https://software-mansion.github.io/react-native-reanimated/transitions.html) and Transition [examples](https://github.com/software-mansion/react-native-reanimated/tree/master/Example/src/transitions).
+  - Extends `Animated.View` props [docs](https://software-mansion.github.io/react-native-reanimated). So you can pass any props you need to customize the animation. eg: `{ entering: { FadeIn } }`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Delay rendering a component until interactions are complete, using `InteractionM
 ### Props
 
 - `placeholder` (optional) Non-heavy React component that renders in the meantime.
-- `transition`: (optional) custom transition prop for Reanimated's `Transitioning.View` component. See `react-native-reanimated` [docs](https://software-mansion.github.io/react-native-reanimated/transitions.html) and Transition [examples](https://github.com/software-mansion/react-native-reanimated/tree/master/Example/src/transitions).
+- Extends `Animated.View` props [docs](https://software-mansion.github.io/react-native-reanimated). So you can pass any props you need to customize the animation. eg: `{ entering: { FadeIn } }`
 
 ```js
 import React from 'react'
@@ -93,12 +93,6 @@ import { optimizeHeavyScreen } from 'react-navigation-heavy-screen'
 export default optimizeHeavyScreen(Screen, OptionalPlaceHolderScreen, {
   // default values
   disableHoistStatics: false,
-  transition: (
-    <Transition.Together>
-      <Transition.Change interpolation="easeInOut" />
-      <Transition.In type="fade" />
-    </Transition.Together>
-  ),
 })
 ```
 

--- a/src/heavy-screen.tsx
+++ b/src/heavy-screen.tsx
@@ -2,7 +2,8 @@ import React, { ComponentPropsWithoutRef, ComponentType } from 'react'
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 import { useAfterInteractions } from './use-after-interactions'
 
-interface Props extends ComponentPropsWithoutRef<typeof Transitioning.View> {
+interface Props extends ComponentPropsWithoutRef<typeof Animated.View> {
+  children?: React.ReactNode,
   placeHolder?: ComponentType
 }
 
@@ -14,7 +15,6 @@ const OptimizedHeavyScreen = ({
   const { transitionRef, areInteractionsComplete } = useAfterInteractions()
   return (
     <Animated.View
-      style={style}
       entering={FadeIn}
       exiting={FadeOut}
       {...rest}

--- a/src/heavy-screen.tsx
+++ b/src/heavy-screen.tsx
@@ -1,30 +1,23 @@
 import React, { ComponentPropsWithoutRef, ComponentType } from 'react'
-import { Transition, Transitioning } from 'react-native-reanimated'
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated'
 import { useAfterInteractions } from './use-after-interactions'
 
-interface Props {
-  transition?: ComponentPropsWithoutRef<typeof Transitioning.View>['transition']
-  children: React.ReactNode
-  style?: ComponentPropsWithoutRef<typeof Transitioning.View>['style']
+interface Props extends ComponentPropsWithoutRef<typeof Transitioning.View> {
   placeHolder?: ComponentType
 }
 
 const OptimizedHeavyScreen = ({
-  transition = (
-    <Transition.Together>
-      <Transition.Change interpolation="easeInOut" />
-      <Transition.In type="fade" />
-    </Transition.Together>
-  ),
-  style,
   children,
   placeHolder: Placeholder,
+  ...rest
 }: Props) => {
   const { transitionRef, areInteractionsComplete } = useAfterInteractions()
   return (
-    <Transitioning.View
-      transition={transition}
+    <Animated.View
       style={style}
+      entering={FadeIn}
+      exiting={FadeOut}
+      {...rest}
       ref={transitionRef}
     >
       {areInteractionsComplete ? (
@@ -32,7 +25,7 @@ const OptimizedHeavyScreen = ({
       ) : !!Placeholder ? (
         <Placeholder />
       ) : null}
-    </Transitioning.View>
+    </Animated.View>
   )
 }
 

--- a/src/optimize-heavy-screen.tsx
+++ b/src/optimize-heavy-screen.tsx
@@ -1,28 +1,22 @@
 import React, { ComponentType, ComponentPropsWithoutRef } from 'react'
-import { Transition, Transitioning } from 'react-native-reanimated'
+import Animated from 'react-native-reanimated'
 // @ts-ignore
 import hoistNonReactStatics from 'hoist-non-react-statics'
 import { useAfterInteractions } from './use-after-interactions'
 import { StyleSheet } from 'react-native'
 
+interface optimizeHeavyScreenOptions extends ComponentPropsWithoutRef<typeof Animated.View> {
+  disableHoistStatics?: boolean
+}
+
 export function optimizeHeavyScreen<Props>(
 	Component: ComponentType<Props>,
 	Placeholder: ComponentType | null = null,
-	options: {
-		disableHoistStatics?: boolean
-		transition?: ComponentPropsWithoutRef<
-			typeof Transitioning.View
-		>['transition']
-	} = {}
+	options: optimizeHeavyScreenOptions = {}
 ) {
 	const {
 		disableHoistStatics = false,
-		transition = (
-			<Transition.Together>
-				<Transition.Change interpolation="easeInOut" />
-				<Transition.In type="fade" />
-			</Transition.Together>
-		),
+    ...rest
 	} = options
 	const OptimizedHeavyScreen = (props: Props) => {
 		const {
@@ -30,8 +24,8 @@ export function optimizeHeavyScreen<Props>(
 			areInteractionsComplete,
 		} = useAfterInteractions()
 		return (
-			<Transitioning.View
-				transition={transition}
+			<Animated.View
+        {...rest}
 				style={styles.container}
 				ref={transitionRef}
 			>
@@ -40,7 +34,7 @@ export function optimizeHeavyScreen<Props>(
 				) : !!Placeholder ? (
 					<Placeholder />
 				) : null}
-			</Transitioning.View>
+			</Animated.View>
 		)
 	}
 	if (!disableHoistStatics) {


### PR DESCRIPTION
Replace v1 API of react-native-reanimated with v3 API since the v1 API has been dropped in v3.

Notes:
I have added a very basic animation. Do let me now we should change that

Closes: https://github.com/nandorojo/react-navigation-heavy-screen/issues/32

Update: Will be using react-navigation with no additions as the current version is optimized enough and this package is not providing ROI